### PR TITLE
Create option to disable audio on setup

### DIFF
--- a/Sources/SwiftUICam/CameraView.swift
+++ b/Sources/SwiftUICam/CameraView.swift
@@ -26,7 +26,9 @@ public struct CameraView: UIViewControllerRepresentable {
     private var tapToFocus: Bool
     private var doubleTapCameraSwitch: Bool
     
-    public init(events: UserEvents, applicationName: String, preferredStartingCameraType: AVCaptureDevice.DeviceType = .builtInWideAngleCamera, preferredStartingCameraPosition: AVCaptureDevice.Position = .back, focusImage: String? = nil, pinchToZoom: Bool = true, tapToFocus: Bool = true, doubleTapCameraSwitch: Bool = true) {
+    private var enableAudio: Bool
+    
+    public init(events: UserEvents, applicationName: String, preferredStartingCameraType: AVCaptureDevice.DeviceType = .builtInWideAngleCamera, preferredStartingCameraPosition: AVCaptureDevice.Position = .back, focusImage: String? = nil, pinchToZoom: Bool = true, tapToFocus: Bool = true, doubleTapCameraSwitch: Bool = true, enableAudio: Bool = true) {
         self.events = events
         
         self.applicationName = applicationName
@@ -38,6 +40,8 @@ public struct CameraView: UIViewControllerRepresentable {
         self.pinchToZoom = pinchToZoom
         self.tapToFocus = tapToFocus
         self.doubleTapCameraSwitch = doubleTapCameraSwitch
+        
+        self.enableAudio = enableAudio
     }
     
     public func makeUIViewController(context: Context) -> CameraViewController {
@@ -53,6 +57,8 @@ public struct CameraView: UIViewControllerRepresentable {
         cameraViewController.pinchToZoom = pinchToZoom
         cameraViewController.tapToFocus = tapToFocus
         cameraViewController.doubleTapCameraSwitch = doubleTapCameraSwitch
+        
+        cameraViewController.audioEnabled = enableAudio
         
         return cameraViewController
     }

--- a/Sources/SwiftUICam/CameraViewController.swift
+++ b/Sources/SwiftUICam/CameraViewController.swift
@@ -370,17 +370,19 @@ public class CameraViewController: UIViewController {
         }
         
         // Add an audio input device.
-        do {
-            let audioDevice = AVCaptureDevice.default(for: .audio)
-            let audioDeviceInput = try AVCaptureDeviceInput(device: audioDevice!)
-            
-            if session.canAddInput(audioDeviceInput) {
-                session.addInput(audioDeviceInput)
-            } else {
-                print("Could not add audio device input to the session")
+        if(audioEnabled){
+            do {
+                let audioDevice = AVCaptureDevice.default(for: .audio)
+                let audioDeviceInput = try AVCaptureDeviceInput(device: audioDevice!)
+
+                if session.canAddInput(audioDeviceInput) {
+                    session.addInput(audioDeviceInput)
+                } else {
+                    print("Could not add audio device input to the session")
+                }
+            } catch {
+                print("Could not create audio device input: \(error)")
             }
-        } catch {
-            print("Could not create audio device input: \(error)")
         }
         
         // Add the photo output.


### PR DESCRIPTION
For my application I need to use the camera and adding another permission for unnecessary microphone data access seems wrong. 

This pull request adds an option input into the `CameraView` initialization to disable audio. This sets the boolean `audioEnabled` in `CameraViewController` and adds a control statement to prevent the AVCapture session from trying to add a microphone.